### PR TITLE
Add ability to query upstream status

### DIFF
--- a/eternalegypt/eternalegypt.py
+++ b/eternalegypt/eternalegypt.py
@@ -21,6 +21,7 @@ class SMS:
 class Information:
     sms = attr.ib(factory=list)
     usage = attr.ib(default=None)
+    upstream = attr.ib(default=None) # possible values seem to be WAN and LTE
 
 @attr.s
 class LB2120:
@@ -106,7 +107,7 @@ class LB2120:
                 _LOGGER.debug("Delete %d with status %d", sms_id, response.status)
 
     async def information(self):
-        """Return the SMS inbox."""
+        """Return the current information."""
         result = Information()
 
         async with async_timeout.timeout(10):
@@ -115,6 +116,7 @@ class LB2120:
                 data = json.loads(await response.text())
 
                 result.usage = data['wwan']['dataUsage']['generic']['dataTransferred']
+                result.upstream = data['failover']['backhaul']
 
                 for msg in [m for m in data['sms']['msgs'] if 'text' in m]:
                     # {'id': '6', 'rxTime': '11/03/18 08:18:11 PM', 'text': 'tak tik', 'sender': '555-987-654', 'read': False}

--- a/examples/upstream.py
+++ b/examples/upstream.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+"""Example file for LB2120 library."""
+
+import sys
+import asyncio
+import aiohttp
+import logging
+
+import eternalegypt
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+async def get_information():
+    """Example of printing the current upstream."""
+    jar = aiohttp.CookieJar(unsafe=True)
+    websession = aiohttp.ClientSession(cookie_jar=jar)
+
+    modem = eternalegypt.Modem(hostname=sys.argv[1], websession=websession)
+    await modem.login(password=sys.argv[2])
+
+    result = await modem.information()
+    print("Upstream: {}".format(result.upstream))
+
+    await websession.close()
+
+if len(sys.argv) != 3:
+    print("{}: <lb2120 ip> <lb2120 password>".format(sys.argv[0]))
+else:
+    asyncio.get_event_loop().run_until_complete(get_information())


### PR DESCRIPTION
Allows to determine whether wireline ("WAN") or mobile ("LTE") upstream is currently active.

I recently got myself one of these fancy modems and was looking for a way to query the current upstream status, in order to be able to trigger certain network config changes for the metered connection.

Stumbled over this project and figured, why not just add this here instead of reinventing the wheel. 

Thanks for the leg work, saved me some trouble :)