### PR TITLE
Catch all KeyError exceptions

### DIFF
--- a/eternalegypt/eternalegypt.py
+++ b/eternalegypt/eternalegypt.py
@@ -223,9 +223,6 @@ class LB2120:
 
     def _build_information(self, data):
         """Read the bits we need from returned data."""
-        if 'wwan' not in data:
-            raise Error()
-
         result = Information()
 
         result.serial_number = data['general']['FSN']
@@ -269,7 +266,11 @@ class LB2120:
         async with self.websession.get(url) as response:
             data = json.loads(await response.text())
 
-            result = self._build_information(data)
+            try:
+                result = self._build_information(data)
+            except KeyError:
+                _LOGGER.debug("Failed to read information: %s", data)
+                raise Error()
 
             self._sms_events(result)
 


### PR DESCRIPTION
This is to handle/debug a reported error that I have been unable to reproduce so far.

```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/netgear_lte/__init__.py", line 313, in _update
    await modem_data.async_update()
  File "/usr/src/homeassistant/homeassistant/components/netgear_lte/__init__.py", line 142, in async_update
    self.data = await self.modem.information()
  File "/usr/local/lib/python3.7/site-packages/eternalegypt/eternalegypt.py", line 60, in wrapper
    return await function(self, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/eternalegypt/eternalegypt.py", line 254, in information
    result = self._build_information(data)
  File "/usr/local/lib/python3.7/site-packages/eternalegypt/eternalegypt.py", line 219, in _build_information
    result.serial_number = data['general']['FSN']
KeyError: 'FSN'
```
