### PR TITLE
Remove some items from key/value dump

### DIFF
--- a/eternalegypt/eternalegypt.py
+++ b/eternalegypt/eternalegypt.py
@@ -49,7 +49,7 @@ class Information:
     current_band = attr.ib(default=None)
     cell_id = attr.ib(default=None)
     sms = attr.ib(factory=list)
-    everything = attr.ib(factory=dict)
+    items = attr.ib(factory=dict)
 
 
 def autologin(function, timeout=TIMEOUT):
@@ -254,10 +254,13 @@ class LB2120:
             result.sms.append(element)
         result.sms.sort(key=lambda sms: sms.id)
 
-        result.everything = {
+        result.items = {
             key.lower(): value
             for key, value in flatten_json.flatten(data, '.').items()
             if value != {}
+            and not re.search(r'\.\d+\.', key)
+            and not re.search(r'\.end$', key)
+            and key.lower() not in ('webd.adminpassword', 'session.sectoken', 'wifi.guest.passphrase', 'wifi.passphrase')
         }
 
         return result

--- a/examples/status.py
+++ b/examples/status.py
@@ -37,7 +37,7 @@ async def get_information():
             print("cell_id: {}".format(result.cell_id))
         else:
             key = sys.argv[3]
-            print("{}: {}".format(key, result.everything.get(key)))
+            print("{}: {}".format(key, result.items.get(key)))
 
         await modem.logout()
     except eternalegypt.Error:


### PR DESCRIPTION
Returning everything (#15) has turned out to be a bit much.

This removes some security sensitive items, "end" keys that are always empty strings as well as all arrays (including SMS messages, list of supported languages and more).