### PR TITLE
Expose signal strength info

### DIFF
--- a/eternalegypt/eternalegypt.py
+++ b/eternalegypt/eternalegypt.py
@@ -27,6 +27,30 @@ class SMS:
     sender = attr.ib()
     message = attr.ib()
 
+@attr.s
+class Signal:
+    """See the following page for good summary of these numbers:
+    https://wiki.teltonika-networks.com/view/Mobile_Signal_Strength_Recommendations#Signal_Measurement
+    """
+
+    """Summary of overall signal quality - 5 good, 1 bad, 0 no signal"""
+    bars = attr.ib(default=None)
+
+    """Indicates the downlink carrier-to-interference ratio (signal quality)"""
+    ecio = attr.ib(default=None)
+
+    """Received Signal Code Power - how strong the signal is"""
+    rscp = attr.ib(default=None)
+
+    """Received Signal Received Quality - the quality of the signal, regardless of strength."""
+    rsrq = attr.ib(default=None)
+
+    """Received Signal Strength Indicator. 0 is strong, -100 is poor."""
+    rssi = attr.ib(default=None)
+
+    """Signal-to-interference-plus-noise ratio"""
+    sinr = attr.ib(default=None)
+
 
 @attr.s
 class Information:
@@ -49,6 +73,7 @@ class Information:
     cell_id = attr.ib(default=None)
     sms = attr.ib(factory=list)
     items = attr.ib(factory=dict)
+    signal = attr.ib(default=None)
 
 
 def autologin(function, timeout=TIMEOUT):
@@ -259,6 +284,19 @@ class LB2120:
         result.tx_level = data['wwanadv']['txLevel']
         result.current_band = data['wwanadv']['curBand']
         result.cell_id = data['wwanadv']['cellId']
+
+        if 'signalStrength' in data['wwan']:
+            signal = Signal()
+
+            signal.bars = data['wwan']['signalStrength']['bars']
+            signal.ecio = data['wwan']['signalStrength']['ecio']
+            signal.rscp = data['wwan']['signalStrength']['rscp']
+            signal.rsrq = data['wwan']['signalStrength']['rsrq']
+            signal.rsrp = data['wwan']['signalStrength']['rsrp']
+            signal.rssi = data['wwan']['signalStrength']['rssi']
+            signal.sinr = data['wwan']['signalStrength']['sinr']
+
+            result.signal = signal
 
         mdy_models = ('MR1100')
 

--- a/examples/status.py
+++ b/examples/status.py
@@ -35,6 +35,7 @@ async def get_information():
             print("tx_level: {}".format(result.tx_level))
             print("current_band: {}".format(result.current_band))
             print("cell_id: {}".format(result.cell_id))
+            print("signal: {}".format(result.signal))
         else:
             key = sys.argv[3]
             print("{}: {}".format(key, result.items.get(key)))

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name="eternalegypt",
     packages=["eternalegypt"],
     version="0.0.13",
-    install_requires=["aiohttp>=3.0.1","attrs"],
+    install_requires=["aiohttp>=3.0.1,<4","attrs"],
     description="Netgear LTE modem API",
     author="Anders Melchiorsen",
     author_email="amelchio@nogoto.net",


### PR DESCRIPTION
I was looking to write a simple Prometheus metrics exporter to monitor signal strength over time - so I've exposed these attributes as `info.signal.bars` etc:
```
Signal(bars=5, ecio=0, rscp=0, rsrq=-9, rssi=-57, sinr=0)
```

Also pinned aiohttp to 3.x as there is an alpha release of 4.0.0 which was causing some warnings, and presumably might need code changes when it's fully released