### PR TITLE
Fix SMS event not firing when no previous messages exist

### DIFF
--- a/eternalegypt/eternalegypt.py
+++ b/eternalegypt/eternalegypt.py
@@ -308,13 +308,14 @@ class LB2120:
             return
 
         if self.max_sms_id is not None:
-            new_sms = (s for s in information.sms if s.id > self.max_sms_id)
-            for sms in new_sms:
+            for sms in (s for s in information.sms if s.id > self.max_sms_id):
                 for listener in self.listeners:
                     listener(sms)
 
         if information.sms:
             self.max_sms_id = max(s.id for s in information.sms)
+        else:
+            self.max_sms_id = 0
 
 
 class Modem(LB2120):

--- a/eternalegypt/eternalegypt.py
+++ b/eternalegypt/eternalegypt.py
@@ -308,7 +308,8 @@ class LB2120:
             return
 
         if self.max_sms_id is not None:
-            for sms in (s for s in information.sms if s.id > self.max_sms_id):
+            new_sms = (s for s in information.sms if s.id > self.max_sms_id)
+            for sms in new_sms:
                 for listener in self.listeners:
                     listener(sms)
 


### PR DESCRIPTION
This is an edge case where the SIM card has no texts saved the first message never gets relayed to the listeners. This PR fixes that and also avoids posting all existing texts upon startup.