### PR TITLE
Clear old cookie information on login

### DIFF
--- a/eternalegypt/eternalegypt.py
+++ b/eternalegypt/eternalegypt.py
@@ -113,6 +113,9 @@ class LB2120:
         else:
             self.password = password
 
+        self.token = None
+        self.websession.cookie_jar.clear(lambda cookie: cookie['domain'] == self.hostname)
+
         try:
             async with asyncio.timeout(TIMEOUT):
                 url = self._url('model.json')


### PR DESCRIPTION
The modem-side session can get stuck in a state returning invalid data. Attempting an auto-login in this situation will just resume the same session, not get out of the bad state.

However, clearing the session cookie before login ensures that a new session with valid data is always created.